### PR TITLE
Adding link to 12-factor config document

### DIFF
--- a/guides/security.md
+++ b/guides/security.md
@@ -9,7 +9,8 @@ The following items should never be committed in a source code or GitHub issues/
 - Proprietary data
 
 If code needs to be aware of this information, it should be stored in a configuration file that is 
-not part of the  repository.
+not part of the repository - e.g. using [environment variables](https://12factor.net/config) loaded
+into the application at runtime.
 
 Additionally, developers should be mindful of application security risks, and should adhere to 
 the [OWASP Top 10](https://www.owasp.org/images/7/72/OWASP_Top_10-2017_%28en%29.pdf.pdf) as best 


### PR DESCRIPTION
/ cc @stscicrawford 

IMO we want our engineers to be following all of the principles of the '12 factor application' when building web applications and services but thought the config section was most relevant for this document.