### PR TITLE
Update readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@ Currently there are styles guides for:
 - [Python](guides/python.md)
 - [Accessibility](guides/accessibility.md)
 - [Security](guides/security.md)
+- [Web Pages](guides/web-styles.md)
 
 In addition, there are the following guides for best practices and workflows:
 - [Git Workflow](guides/git-workflow.md)
+- [PR Review](guides/git-pr-review.md)
 - [Software Versioning](guides/software-versioning.md)
 - [Python Packaging](guides/python-package.md)
+- [Storing Data](guides/where-to-put-your-data.md)
 
 
 ### Related work


### PR DESCRIPTION
A few of the style guides were missing from the README.  I think this syncs things back up again.

(This is pretty trivial so if no one else gets to it in a few days I can merge it myself).