### PR TITLE
DOI for each release of our public software

### DIFF
--- a/guides/software-versioning.md
+++ b/guides/software-versioning.md
@@ -43,6 +43,17 @@ version. This should be enforced by automated tools where practical (e.g.,
 the Python package templates require a "release" tag to be set, and scripts
 automatically use that to append "dev" to the version).
 
+### DOI For Software Releases
+
+Our open source software available to the public should include a DOI (Digitial
+Object Identifier) that has now become the standard for journal articles.
+Including a DOI for each released verison of software will enable (and
+encourage!) the public to reference our software and even more the specific
+version they used.  [Zenoodo](https://zenodo.org) enables the automatic DOI
+creation when a release is done on GitHub.  The place to start is by [logging
+in to Zenodo](https://zenodo.org/login/?next=%2Faccount%2Fsettings%2Fgithub%2F). There
+is some discussion of how to do it [on a GitHub guide](https://guides.github.com/activities/citable-code/).
+
 
 ### Software others build
 

--- a/guides/software-versioning.md
+++ b/guides/software-versioning.md
@@ -43,7 +43,7 @@ version. This should be enforced by automated tools where practical (e.g.,
 the Python package templates require a "release" tag to be set, and scripts
 automatically use that to append "dev" to the version).
 
-### DOI For Software Releases
+### DOI for software releases
 
 Our open source software available to the public should include a DOI (Digitial
 Object Identifier) that has now become the standard for journal articles.

--- a/guides/software-versioning.md
+++ b/guides/software-versioning.md
@@ -50,9 +50,9 @@ Object Identifier) that has now become the standard for journal articles.
 Including a DOI for each released verison of software will enable (and
 encourage!) the public to reference our software and even more, the specific
 version they used.  [Zenodo](https://zenodo.org) enables the automatic DOI
-creation when a release is done on GitHub.  The place to start is by [logging
-in to Zenodo](https://zenodo.org/login/?next=%2Faccount%2Fsettings%2Fgithub%2F). There
-is a discussion of how to do it [on a GitHub guide](https://guides.github.com/activities/citable-code/).
+creation when a release is done on GitHub.  Follow the discussion [on the
+GitHub guide](https://guides.github.com/activities/citable-code/) in order to
+use DOI's for your code releases.
 
 ### Software others build
 

--- a/guides/software-versioning.md
+++ b/guides/software-versioning.md
@@ -48,12 +48,11 @@ automatically use that to append "dev" to the version).
 Our open source software available to the public should include a DOI (Digitial
 Object Identifier) that has now become the standard for journal articles.
 Including a DOI for each released verison of software will enable (and
-encourage!) the public to reference our software and even more the specific
-version they used.  [Zenoodo](https://zenodo.org) enables the automatic DOI
+encourage!) the public to reference our software and even more, the specific
+version they used.  [Zenodo](https://zenodo.org) enables the automatic DOI
 creation when a release is done on GitHub.  The place to start is by [logging
 in to Zenodo](https://zenodo.org/login/?next=%2Faccount%2Fsettings%2Fgithub%2F). There
-is some discussion of how to do it [on a GitHub guide](https://guides.github.com/activities/citable-code/).
-
+is a discussion of how to do it [on a GitHub guide](https://guides.github.com/activities/citable-code/).
 
 ### Software others build
 


### PR DESCRIPTION
There was some discussion on one sprint team about how to reference our software. Obviously DOI has become the standard for referencing journal articles with a link, this seems to be an obvious way to do it for released software as well.

So, for discussion, an opinionated thought is that we should have a Zenodo DOI for each released piece of software and for the GitHub repo as well (which will then point to the latest).   This is up for discussion and I think this would be a good place for the discussion.

(I will probably re-write the text in the PR a bit, but wanted to prompt the discussion.)

@hcferguson @arfon @eteq @stscicrawford 