### PR TITLE
Jupyter notebook style guide revision

### DIFF
--- a/guides/jupyter-notebooks.md
+++ b/guides/jupyter-notebooks.md
@@ -1,11 +1,14 @@
 # Jupyter Notebooks and Tutorials
 
-This guide describes best practices for creating readable (easy to understand),
-portable (likely to work on many computers) tutorials. Jupyter Notebooks are a
-convenient format for creating and sharing documents that combine code, data
-analyses, visualizations, and prose, which are the key components of a tutorial.
-Following this guide is a requirement for those authors contributing content to
-the [STScI notebooks repository](https://github.com/spacetelescope/notebooks).
+Jupyter Notebooks are a convenient format for creating and sharing documents
+that combine code, data analyses, visualizations, and prose, which are the key
+components of a tutorial. This guide describes best practices for creating
+readable (easy to understand) and portable (likely to work on many computers)
+notebooks. Following this guide is a requirement for those authors contributing
+content to the [STScI notebooks
+repository](https://github.com/spacetelescope/notebooks). This style guide, when
+not documenting notebook-specific syntax, also applies to other formats like
+non-notebook tutorials or example descriptions.
 
 ## Example notebook
 
@@ -148,11 +151,11 @@ It's recommended that tutorials use the following suggested structure:
 
 - [Title](#title)
 - [Learning Goals](#learning-goals)
-- [Imports](#imports)
 - [Introduction](#introduction)
-- [Loading Data](#loading-data)
-- [File Information](#file-information)
+- [Imports](#imports)
 - [Main Content](#main-content) (xN)
+  - [Loading Data](#loading-data)
+  - [File Information](#file-information)
 - [Exercises](#exercises) (encouraged)
 - [Additional Resources](#additional-resources) (optional)
 - [About this Notebook](#about-this-notebook)
@@ -218,15 +221,6 @@ By the end of this tutorial, you will be able to:
 
 ```
 
-### Imports
-
-.. suggestion to move Imports to after Introduction
-
-Import your dependencies near the top of the tutorial and explain why you're
-including each one. For example:
-
-![Imports](images/imports.png)
-
 ### Introduction
 
 Write a short introduction explaining the purpose of the tutorial. Define any
@@ -241,44 +235,12 @@ continuation from another tutorial, or there are other tutorials that would be
 useful for the reader to read before or after your tutorial, mention that here
 as well.
 
-### Loading Data
+### Imports
 
-.. suggestion to move Loading Data and File Information into the Main Content
-   section, with an explanation that these can be their own sections within the
-   Main Content, but avoid generic/vague headings like “Loading Data” and
-   instead use descriptive headings pertinent to the content of the tutorial and
-   the actual data being downloaded or files being used. So instead of vague
-   headings like "Downloading data," instead use something like “Downloading
-   Multiple `KeplerLightCurve` Objects at Once.”
+Import your dependencies after the introduction and explain why you're including
+each one. For example:
 
-If the user needs to download data to run the tutorial properly, where possible,
-use [Astroquery](https://astroquery.readthedocs.io/en/latest/) (or similar) to
-retrieve files. If this is not possible, see the [data
-guide](where-to-put-your-data.md) for other options.
-
-### File Information
-
-Explain pertinent details about the file you've just downloaded. For example, if
-working with Kepler light curves, explain what's in the different file
-extensions:
-
-```
-- No. 0 (Primary): This HDU contains metadata related to the entire file.
-- No. 1 (Light curve): This HDU contains a binary table that holds data like
-  flux measurements and times. We will extract information from here when we
-  define the parameters for the light curve plot.
-- No. 2 (Aperture): This HDU contains the image extension with data collected
-  from the aperture. We will also use this to display a bitmask plot that
-  visually represents the optimal aperture used to create the SAP_FLUX column in
-  HDU1.
-
-```
-
-Where possible (if the code supports it), use code examples that visually
-display the data in the tutorial. For example, if you are showing an object that
-can be read as an Astropy table, display the table:
-
-![show-data-example](images/notebook_table_data_example.png)
+![Imports](images/imports.png)
 
 ### Main Content
 
@@ -304,20 +266,63 @@ subsections.
 ```
 
 Be sure to use the Markdown headings (that is, the number of `#`'s) in a way
-that gives hierarchical meaning to your tutorial. The header levels are used to
+that gives hierarchical meaning to your tutorial. The heading levels are used to
 do things like intelligently make links and the Table of Contents, so you don't
-want to confuse things by using header levels that don't match the logical flow
+want to confuse things by using heading levels that don't match the logical flow
 of the tutorial.
+
+Loading data and file information should appear within your main content, at the
+same time the data is going to be used, if possible. These elements of your
+tutorial can be their own sections within the main content, but avoid generic or
+vague headings like “Loading Data” and instead use descriptive headings
+pertinent to the content of the tutorial and the actual data being downloaded or
+files being used. For example, instead of a vague heading like "Downloading
+Data," use something like “Downloading Multiple `KeplerLightCurve` Objects at
+Once.” For additional details on loading data and file information, read the
+following sections.
+
+#### Loading Data
+
+If the user needs to download data to run the tutorial properly, where possible,
+use [Astroquery](https://astroquery.readthedocs.io/en/latest/) (or similar) to
+retrieve files. If this is not possible, see the [data
+guide](where-to-put-your-data.md) for other options.
+
+#### File Information
+
+Explain pertinent details about the file you've just downloaded. For example, if
+working with Kepler light curves, explain what's in the different file
+extensions:
+
+```
+- No. 0 (Primary): This HDU contains metadata related to the entire file.
+- No. 1 (Light curve): This HDU contains a binary table that holds data like
+  flux measurements and times. We will extract information from here when we
+  define the parameters for the light curve plot.
+- No. 2 (Aperture): This HDU contains the image extension with data collected
+  from the aperture. We will also use this to display a bitmask plot that
+  visually represents the optimal aperture used to create the SAP_FLUX column in
+  HDU1.
+
+```
+
+Where possible (if the code supports it), use code examples that visually
+display the data in the tutorial. For example, if you are showing an object that
+can be read as an Astropy table, display the table:
+
+![show-data-example](images/notebook_table_data_example.png)
+
+#### Terms and Resources
 
 All terms and relevant additional resources should be defined and linked to as
 new topics are introduced and your tutorial progresses, so that terms and
 resources appear within the context of your main content. Short exercises can be
-woven into your Main Content sections as well.
+woven into your main content sections as well.
 
 ### Exercises
 
-Exercises are optional, but encouraged. Exercises can be woven into the Main
-Content of your tutorial, or appear in their own section toward the end of the
+Exercises are optional, but encouraged. Exercises can be woven into the main
+content of your tutorial, or appear in their own section toward the end of the
 tutorial. Final exercises can be more challenging, similar to homework problems.
 They can be minimal or take as long as 30 minutes to an hour to complete.
 
@@ -335,17 +340,11 @@ attempt.
 
 ### Additional Resources
 
-.. suggestion to remove the Additional Resources section and instead ask
-   tutorial authors to include additional resources in line with the context of
-   their main content, instead of in a separate list at the end that has no
-   context.
-
-While this section isn't always necessary, sometimes you want to provide more
-resources for the reader who wants to learn something beyond what's in your
-tutorial. Sometimes these resources don't exist, but if they do, it's good to
-put them at the end of your tutorial to give the reader somewhere else to go.
-Usually a list of links using Markdown bullet list plus link format is
-appropriate:
+This section is optional. Try to weave resource links into the main content of
+your tutorial so that they are falling in line with the context of your writing.
+For resources that do not fit cleanly into your narrative, you may include an
+additional resources section at the end of your tutorial. Usually a list of
+links using Markdown bullet list plus link format is appropriate:
 
 ```
 * [A neat resource to learn

--- a/guides/jupyter-notebooks.md
+++ b/guides/jupyter-notebooks.md
@@ -1,39 +1,36 @@
-# Jupyter Notebooks
+# Jupyter Notebooks and Tutorials
 
-.. do we want to specify that this is a guide for creating notebooks and
-   tutorials, or would no one ever be contributing a tutorial that wasn't
-   created in a Jupyter notebook? As in, are the terms "notebook" and "tutorial"
-   interchangeable?
-
-Jupyter Notebooks are a convenient format for creating and sharing documents
-that combine code, data analyses, visualizations, and prose. This guide
-describes best practices for creating readable (easy to understand), portable
-(likely to work on many computers) notebooks. Following this guide is a
-requirement for those authors contributing content to the [STScI notebooks
-repository](https://github.com/spacetelescope/notebooks).
+This guide describes best practices for creating readable (easy to understand),
+portable (likely to work on many computers) tutorials. Jupyter Notebooks are a
+convenient format for creating and sharing documents that combine code, data
+analyses, visualizations, and prose, which are the key components of a tutorial.
+Following this guide is a requirement for those authors contributing content to
+the [STScI notebooks repository](https://github.com/spacetelescope/notebooks).
 
 ## Example notebook
 
-This [example notebook](../templates/example_notebook.ipynb) implements this
-style guide with placeholder content. If you want to create a new notebook
-following this guide then you might want to start from this one.
+This [example notebook](../templates/example_notebook.ipynb) provides a tutorial
+template with placeholder content based on this style guide. If you want to
+create a new tutorial following this guide, then you might want to start from
+this example notebook.
 
 ## Design principles
 
 ### Make no assumptions
 
-As the notebook author, don't assume people know the same things as you. This
-means any terms or common acronyms should be defined when they are first used.
-It you're using some kind of astronomical parameter, make sure you define it
-(for example, in its mathematical form) or link to any definitions (literature,
-Wikipedia, etc.). If you think this is making your notebook too detailed, use
-clearly-named sections with appropriate introductions, or split your notebook
-into two separate ones that reference each other.
+As the tutorial author, don't assume people know the same things as you. This
+means that any terms or common acronyms should be defined when they are first
+used. It you're using some kind of astronomical parameter, make sure you define
+it (for example, in its mathematical form) or link to any definitions
+(literature, Wikipedia, etc.). If you think this information is making your
+tutorial too detailed, use clearly named sections with appropriate
+introductions, or split your tutorial into two separate tutorials that reference
+each other.
 
-Above all, know your audience: if you are writing a notebook only for
-astronomers in a specific field, you might be more terse on background. But if
-so, *say so* at the beginning of your notebook, and know that most readers will
-not get anything from it.
+Above all, know your audience: if you are writing a tutorial for astronomers in
+a specific field, you might be more terse on background. But if so, *say so* at
+the beginning of your tutorial, and know that most readers will not get anything
+from it.
 
 Always avoid assumptive or belittling words such as “obviously,” “easily,”
 “simply,” “just,” or “straightforward.” Avoid words or phrases that create worry
@@ -42,9 +39,9 @@ confidence in the skills being learned.
 
 ### Design for portability
 
-Notebooks should be portable, that is, they should be designed to work on
-multiple computers. There are a few basic steps you can take as a notebook
-author to increase the "portability" of a notebook:
+Tutorials should be portable, that is, they should be designed to work on
+multiple computers. There are a few basic steps you can take as a tutorial
+author to increase the "portability" of a tutorial notebook:
 
 - Use APIs, not file systems, to access data. Where possible, use libraries such
   as [`astroquery.mast`](https://astroquery.readthedocs.io/en/latest/) to
@@ -62,7 +59,7 @@ author to increase the "portability" of a notebook:
   have good internet access or a fast computer when they try to run your
   notebook. Instead, try to use compact examples that work on smaller portions
   of a dataset. While this is not always possible given the goals of a
-  particular notebook, it is best to strive for it. At the very least, be sure
+  particular tutorial, it is best to strive for it. At the very least, be sure
   to warn the user clearly if a notebook will have long runtime or large
   downloads.
 - Avoid using any unnecessary non-markdown constructs. While it's tempting to
@@ -75,7 +72,7 @@ author to increase the "portability" of a notebook:
 
 ![A notebook cell](images/notebook-cell.png)
 
-Creating a new notebook can take time, and in the development process, some
+Creating a new tutorial can take time, and in the development process, some
 content cells (code and prose) may become out of date or superfluous. Before
 committing your work to a source repository, make sure that:
 
@@ -132,7 +129,7 @@ guide](where-to-put-your-data.md) for details on how to do this). As shown
 previously, if your notebook needs ancillary files, you should include them at
 the same level as your notebook.
 
-Similarly, if your notebook involves *writing* files, you should write the
+Similarly, if your tutorial involves *writing* files, you should write the
 notebook so that they are written in the same location. As an example, if you
 are making a scatter plot using matplotlib and want to demonstrate to the user
 how to save it, you can do this in the notebook:
@@ -145,19 +142,17 @@ plt.savefig('result-plot.png')
 
 And the image will end up in the same place as any ancillary files.
 
-## Recommended notebook and tutorial structure
+## Recommended tutorial structure
 
-It's recommended that Jupyter notebooks and STScI tutorials use the following
-suggested structure:
+It's recommended that tutorials use the following suggested structure:
 
 - [Title](#title)
-- [Table of Contents](#table-of-contents)
 - [Learning Goals](#learning-goals)
 - [Imports](#imports)
 - [Introduction](#introduction)
 - [Loading Data](#loading-data)
 - [File Information](#file-information)
-- [Sections](#sections) (xN)
+- [Main Content](#main-content) (xN)
 - [Exercises](#exercises) (encouraged)
 - [Additional Resources](#additional-resources) (optional)
 - [About this Notebook](#about-this-notebook)
@@ -176,41 +171,27 @@ syntax](https://www.markdownguide.org/basic-syntax/#headings):
 
 ```
 
-### Table of Contents
-
-Provide a table of contents to help readers quickly navigate the sections of
-your notebook. Use the following [Markdown
-syntax](https://www.markdownguide.org/basic-syntax/):
-
-```
-## Table of Contents
-- [My First Section](#my-first-section)
-- [My Second Section](#my-second-section)
-- [My Third Section](#my-third-section)
-
-```
-
 ### Learning Goals
 
-Every notebook should contain three to five explicit learning goals. A learning
+Every tutorial should contain three to five explicit learning goals. A learning
 goal should describe what a reader should know or be able to do by the end of
-the notebook that they didn't know or couldn't do before.
+the tutorial that they didn't know or couldn't do before.
 
 Learning goals can be broken down into:
 
-- Skills: what the reader should be able to do by the end of the notebook.
-- Knowledge: what the reader should understand by the end of the notebook.
+- Skills: what the reader should be able to do by the end of the tutorial.
+- Knowledge: what the reader should understand by the end of the tutorial.
 - Attitudes: what the reader's opinions about the subject matter will be by the
-  end of the notebook.
+  end of the tutorial.
 
-To create your notebook learning goals, write sentences that identify what
-skill, knowledge, or attitude the reader will gain from your notebook, and use
+To create your tutorial learning goals, write sentences that identify what
+skill, knowledge, or attitude the reader will gain from your tutorial, and use
 strong action verbs (understand, explain, demonstrate, determine, create,
 access, calculate, analyze).
 
 Template learning goal sentence:
 
-By the end of this notebook, you will be able to (skill) in order to
+By the end of this tutorial, you will be able to (skill) in order to
 (knowledge).
 
 #### Examples
@@ -239,39 +220,36 @@ By the end of this tutorial, you will be able to:
 
 ### Imports
 
-Import your dependencies near the top of the notebook and explain why you're
+.. suggestion to move Imports to after Introduction
+
+Import your dependencies near the top of the tutorial and explain why you're
 including each one. For example:
 
 ![Imports](images/imports.png)
 
 ### Introduction
 
-Write a short introduction explaining the purpose of the notebook. If there are
-background materials or resources that may be useful to the reader to provide
-additional context, you may link to it here.
-
-#### Defining Terms
-
-As a subsection of your introduction section, define any terms or common
-acronyms that your audience may not know. If you're using some kind of
-domain-specific astronomical symbol or unusual mathematical concept, make sure
-you define it (for example, in its mathematical form) and link to any
+Write a short introduction explaining the purpose of the tutorial. Define any
+terms or common acronyms that your audience may not know. If you're using some
+kind of domain-specific astronomical symbol or unusual mathematical concept,
+make sure you define it (for example, in its mathematical form) and link to any
 definitions (from literature, Wikipedia, etc.).
 
-#### Companion Content
-
-As a subsection of your introduction section, link to any helpful companion
-content. For example, if your notebook is a continuation from another notebook,
-or there are other notebooks that would be useful for the reader to read before
-or after your notebook, mention that here.
+If there are background materials or resources that may be useful to the reader
+to provide additional context, you may link to it here. If your tutorial is a
+continuation from another tutorial, or there are other tutorials that would be
+useful for the reader to read before or after your tutorial, mention that here
+as well.
 
 ### Loading Data
 
-.. should Loading Data and File Information go right after Imports? It seems
-   funny to have the Introduction separated from the main content by these two
-   sections, and might look cleaner to have all of the importing/downloading
-   info together before the learning material starts, but is there a specific
-   reason for this order?
+.. suggestion to move Loading Data and File Information into the Main Content
+   section, with an explanation that these can be their own sections within the
+   Main Content, but avoid generic/vague headings like “Loading Data” and
+   instead use descriptive headings pertinent to the content of the tutorial and
+   the actual data being downloaded or files being used. So instead of vague
+   headings like "Downloading data," instead use something like “Downloading
+   Multiple `KeplerLightCurve` Objects at Once.”
 
 If the user needs to download data to run the tutorial properly, where possible,
 use [Astroquery](https://astroquery.readthedocs.io/en/latest/) (or similar) to
@@ -296,17 +274,17 @@ extensions:
 
 ```
 
-Where possible (if the code supports it), use code examples that use Jupyter to
-*show* what's in the data. For example, if you are showing an object that can be
-read as an Astropy table, display the table:
+Where possible (if the code supports it), use code examples that visually
+display the data in the tutorial. For example, if you are showing an object that
+can be read as an Astropy table, display the table:
 
 ![show-data-example](images/notebook_table_data_example.png)
 
-### Sections
+### Main Content
 
-The main content of your notebook should be subdivided into numbered sections
-with useful names that make sense based on the content. Break sections up with
-standard [Markdown syntax
+The main content of your tutorial should be subdivided into numbered sections
+with useful, descriptive headings that make sense based on the content. Break
+sections up with standard [Markdown syntax
 headings](https://www.markdownguide.org/basic-syntax/#headings):
 
 ```
@@ -326,30 +304,46 @@ subsections.
 ```
 
 Be sure to use the Markdown headings (that is, the number of `#`'s) in a way
-that gives hierarchical meaning to your document. The header levels are used to
-do things like intelligently make links, so you don't want to confuse things by
-using header levels that don't match the logical flow of the document.
+that gives hierarchical meaning to your tutorial. The header levels are used to
+do things like intelligently make links and the Table of Contents, so you don't
+want to confuse things by using header levels that don't match the logical flow
+of the tutorial.
+
+All terms and relevant additional resources should be defined and linked to as
+new topics are introduced and your tutorial progresses, so that terms and
+resources appear within the context of your main content. Short exercises can be
+woven into your Main Content sections as well.
 
 ### Exercises
 
-Most notebooks convey information to their reader by posing questions and then
+Exercises are optional, but encouraged. Exercises can be woven into the Main
+Content of your tutorial, or appear in their own section toward the end of the
+tutorial. Final exercises can be more challenging, similar to homework problems.
+They can be minimal or take as long as 30 minutes to an hour to complete.
+
+Most tutorials convey information to their reader by posing questions and then
 providing answers. But as so many of us learn by doing, it's encouraged for you
-to provide exercises in your notebook that pose questions but do not include
+to provide exercises in your tutorial that pose questions but do not include
 immediate answers so that your reader can practice their new skills to cement
 the knowledge in their minds.
 
 If you do have one or more exercises, be sure to leave a blank code cell
-underneath to show the reader that they're meant to try out their new skill
+underneath each to show the reader that they're meant to try out their new skill
 right there. You may also want to include a "solutions" notebook next to your
 main notebook for the reader to check their work after they have finished their
 attempt.
 
 ### Additional Resources
 
+.. suggestion to remove the Additional Resources section and instead ask
+   tutorial authors to include additional resources in line with the context of
+   their main content, instead of in a separate list at the end that has no
+   context.
+
 While this section isn't always necessary, sometimes you want to provide more
-resources for the reader who wants to learn something beyond what's in the
-notebook. Sometimes these resources don't exist, but if they do, it's good to
-put them at the end of your notebook to give the reader somewhere else to go.
+resources for the reader who wants to learn something beyond what's in your
+tutorial. Sometimes these resources don't exist, but if they do, it's good to
+put them at the end of your tutorial to give the reader somewhere else to go.
 Usually a list of links using Markdown bullet list plus link format is
 appropriate:
 
@@ -362,14 +356,12 @@ appropriate:
 
 ### About this Notebook
 
-Let the world know who the author of this great notebook is! If possible and
+Let the world know who the author of this great tutorial is! If possible and
 appropriate, include a contact email address for users who might need support
-(for example, `archive@stsci.edu`). You can also optionally include keywords or
-your funding source in this section.
+(for example, `archive@stsci.edu`). You can also optionally include keywords,
+your funding source, or a last update date in this section.
 
 ### Citations
-
-.. what else needs to go in this section?
 
 Provide your reader with guidelines on how to cite open source software and
 other resources in their own published work.
@@ -411,9 +403,9 @@ Dictionary](https://www.merriam-webster.com/). STScI writing guidelines are in
 agreement with the [Astropy Narrative Style
 Guide](https://docs.astropy.org/en/stable/development/style-guide.html).
 
-### Example notebooks following this style guide
+### Example tutorials following this style guide
 
-Here are some example notebooks that follow this style guide:
+Here are some example tutorials that follow this style guide:
 
 - [An example notebook with placeholder content](../templates/example_notebook.ipynb)
 - [Kepler Full Frame Images (FFI)](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/Kepler_FFI/kepler_ffi.ipynb)
@@ -422,7 +414,7 @@ Here are some example notebooks that follow this style guide:
 
 ### Other Resources
 
-For a related view of notebook styles in the astronomy context, see the [Astropy
+For a related view of tutorial styles in the astronomy context, see the [Astropy
 Contributing Guide](http://learn.astropy.org/contributing.html).
 
 ### Contributing to the STScI notebooks repository

--- a/guides/jupyter-notebooks.md
+++ b/guides/jupyter-notebooks.md
@@ -1,47 +1,117 @@
 # Jupyter Notebooks
 
-Jupyter Notebooks are a convenient format for creating and sharing documents that combine code, data analyses, visualizations, and prose. This guide describes best practices for creating readable (easy to understand), portable (likely to work on many computers) notebooks. Following this guide is a requirement for those authors contributing content to the [STScI notebooks repository](https://github.com/spacetelescope/notebooks).
+.. do we want to specify that this is a guide for creating notebooks and
+   tutorials, or would no one ever be contributing a tutorial that wasn't
+   created in a Jupyter notebook? As in, are the terms "notebook" and "tutorial"
+   interchangeable?
+
+Jupyter Notebooks are a convenient format for creating and sharing documents
+that combine code, data analyses, visualizations, and prose. This guide
+describes best practices for creating readable (easy to understand), portable
+(likely to work on many computers) notebooks. Following this guide is a
+requirement for those authors contributing content to the [STScI notebooks
+repository](https://github.com/spacetelescope/notebooks).
 
 ## Example notebook
 
-[This example notebook](../templates/example_notebook.ipynb) implements this style guide with placeholder content. If you want to create a new notebook following this guide then you might want to start from this one.
+This [example notebook](../templates/example_notebook.ipynb) implements this
+style guide with placeholder content. If you want to create a new notebook
+following this guide then you might want to start from this one.
 
 ## Design principles
 
 ### Make no assumptions
 
-As the notebook author, don't assume people know the same things as you. This means any terms/common acronyms should be defined when they are first used. It you're using some kind of astronomical parameter, make sure you define it (e.g. in its mathematical form) or link to any definitions (literature/Wikipedia etc.). If you think this is making your notebook too detailed, use clearly-named sections with appropriate introductions, or split your notebook into two separate ones that reference each other.
+As the notebook author, don't assume people know the same things as you. This
+means any terms or common acronyms should be defined when they are first used.
+It you're using some kind of astronomical parameter, make sure you define it
+(for example, in its mathematical form) or link to any definitions (literature,
+Wikipedia, etc.). If you think this is making your notebook too detailed, use
+clearly-named sections with appropriate introductions, or split your notebook
+into two separate ones that reference each other.
 
-Above all, know your audience: if you are writing a notebook only for astronomers in a specific field, you might be more terse on background.  But if so, *say so* at the beginning of your notebook, and know that most readers will not get anything from it.
+Above all, know your audience: if you are writing a notebook only for
+astronomers in a specific field, you might be more terse on background. But if
+so, *say so* at the beginning of your notebook, and know that most readers will
+not get anything from it.
+
+Always avoid assumptive or belittling words such as “obviously,” “easily,”
+“simply,” “just,” or “straightforward.” Avoid words or phrases that create worry
+in the mind of the reader. Instead, use positive language that establishes
+confidence in the skills being learned.
 
 ### Design for portability
 
-Notebooks should be portable, that is, they should be designed to work on multiple computers. There are a few simple steps you can take as a notebook author to increase the 'portability' of a notebook:
+Notebooks should be portable, that is, they should be designed to work on
+multiple computers. There are a few basic steps you can take as a notebook
+author to increase the "portability" of a notebook:
 
-- Use APIs not file systems to access data. Where at all possible, use libraries such as [`astroquery.mast`](https://astroquery.readthedocs.io/en/latest/) to retrieve the data required for your notebook. Never hard-code a path to a file on e.g. a shared filesystem. See the [data guide](where-to-put-your-data.md) for more detail on how you might implement this.
-- If you need specific packages installed to enable your notebook to execute, define them in a custom [`requirements.txt`](https://pip.pypa.io/en/stable/reference/pip_install/#example-requirements-file) file that can be used to install these dependencies.  Be as specific as possible: sometimes packages make backward incompatible changes, so specifying a particular version of dependencies will protect against that.
-- Try to avoid long-running computations or large downloads.  Not all users will have good internet access or a fast computer when they try to run your notebook.  Instead, try to use compact examples that work on smaller portions of a dataset. While this is not always possible given the goals of a particular notebook, it is best to strive for it.  At the very least be sure to warn the user clearly if a notebook will have long runtime/large downloads.
-- Avoid using any unnecessary non-markdown constructs.  While it's tempting to use HTML directly in a notebook cell, it's best avoided if at all possible, because there's no guarantee that the notebook viewer is in the same web site all the time. Markdown, meanwhile, is specifically designed with that portability in mind.
+- Use APIs, not file systems, to access data. Where possible, use libraries such
+  as [`astroquery.mast`](https://astroquery.readthedocs.io/en/latest/) to
+  retrieve the data required for your notebook. Never hard-code a path to a file
+  on, for example, a shared filesystem. See the [data
+  guide](where-to-put-your-data.md) for more detail on how you might implement
+  this.
+- If you need specific packages installed to enable your notebook to execute,
+  define them in a custom
+  [`requirements.txt`](https://pip.pypa.io/en/stable/reference/pip_install/#example-requirements-file)
+  file that can be used to install these dependencies. Be as specific as
+  possible: sometimes packages make backward incompatible changes, so specifying
+  a particular version of dependencies will protect against that.
+- Try to avoid long-running computations or large downloads. Not all users will
+  have good internet access or a fast computer when they try to run your
+  notebook. Instead, try to use compact examples that work on smaller portions
+  of a dataset. While this is not always possible given the goals of a
+  particular notebook, it is best to strive for it. At the very least, be sure
+  to warn the user clearly if a notebook will have long runtime or large
+  downloads.
+- Avoid using any unnecessary non-markdown constructs. While it's tempting to
+  use HTML directly in a notebook cell, it's best avoided if at all possible,
+  because there's no guarantee that the notebook viewer is in the same website
+  all the time. Markdown, meanwhile, is specifically designed with that
+  portability in mind.
 
 ### Keep good cell discipline
 
 ![A notebook cell](images/notebook-cell.png)
 
-Creating a new notebook can take time, and in the development process, some content cells (code and prose) may become out of date/superfluous. Before committing your work to a source repository, make sure that:
+Creating a new notebook can take time, and in the development process, some
+content cells (code and prose) may become out of date or superfluous. Before
+committing your work to a source repository, make sure that:
 
-- Cells capture logical units of work. i.e. don't put all of your code in a single giant cell of logic. Try and break it out into smaller units, inter-dispersed with text explaining what you are doing.
-- All of the cells are required and *in order*. i.e., you can go from the start of your notebook to the end, executing each cell. Cells should only fail if they are *meant* to, because you're illustrating the meaning of an error message or similar.
-- Checked-in notebook shouldn't contain the executed cell outputs. Any results you check in take up valuable space in the notebook, making it harder to review and bloating the repository. When your notebook is checked into the [STScI notebooks repository](https://github.com/spacetelescope/notebooks), we will run [`nbconvert`](https://nbconvert.readthedocs.io/en/latest/) to execute your notebook (overriding anything already executed) and [`sphinx`](http://www.sphinx-doc.org/) to create web-hosted versions.
+- Cells capture logical units of work. That is, don't put all of your code in a
+  single giant cell of logic. Try to break it out into smaller units,
+  interspersed with text explaining what you are doing.
+- All of the cells are required and *in order*. That is, you can go from the
+  start of your notebook to the end, executing each cell. Cells should only fail
+  if they are *meant* to, because you're illustrating the meaning of an error
+  message or something similar.
+- Checked-in notebooks shouldn't contain the executed cell outputs. Any results
+  you check in take up valuable space in the notebook, making it harder to
+  review and bloating the repository. When your notebook is checked into the
+  [STScI notebooks repository](https://github.com/spacetelescope/notebooks), we
+  will run [`nbconvert`](https://nbconvert.readthedocs.io/en/latest/) to execute
+  your notebook (overriding anything already executed) and
+  [`sphinx`](http://www.sphinx-doc.org/) to create web-hosted versions.
 
 ### Write readable prose using Markdown
 
-Use cells with [Markdown](https://www.markdownguide.org/basic-syntax/#paragraphs-1) formatting to describe anything that isn't actually code.  Also use them either before or after code cells to describe what's happening.  When mathematical expressions are needed, use the [Jupyter additions to markdown](https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#markdown-cells), which are basically carefully-controlled LaTeX.
+Use cells with
+[Markdown](https://www.markdownguide.org/basic-syntax/#paragraphs-1) formatting
+to describe anything that isn't actually code. Also use them either before or
+after code cells to describe what's happening. When mathematical expressions are
+needed, use the [Jupyter additions to
+Markdown](https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#markdown-cells),
+which are basically carefully controlled LaTeX.
 
-Only use code comments when it's a natural inline comment directly connected to that line of code.  Do **not** use code cells with comments to replace well-written prose!
+Only use code comments when it's a natural inline comment directly connected to
+that line of code. Do **not** use code cells with comments to replace
+well-written prose!
 
 ## On-disk layout and ancillary/generated files
 
-Individual notebooks should live in their own directory along side any ancillary files related to them.  For example:
+Individual notebooks should live in their own directory alongside any ancillary
+files related to them. For example:
 
 ```
 notebooks/
@@ -50,108 +120,270 @@ notebooks/
 |    +-- object-data.csv
 |    +-- result-plot.png
 |    +-- requirements.txt
+
 ```
 
-As this demonstrates, sometimes it is appropriate to include ancillary files with your notebook. Examples include small images or data files (E.g., FITS cutouts not accessible via MAST, or CSV tables). Files of any significant size (> 100 kB is a good rule of thumb) should not be included with the notebook but rather stored outside the repository and accessed via code (see [the data guide](where-to-put-your-data.md) for details on how to do this). As shown above, if your notebook needs ancillary files, you should include them at the same level as your notebook.
+As this demonstrates, sometimes it is appropriate to include ancillary files
+with your notebook. Examples include small images or data files such as FITS
+cutouts not accessible via MAST, or CSV tables. Files of any significant size (>
+100 kB is a good rule of thumb) should not be included with the notebook but
+rather stored outside of the repository and accessed via code (go to [the data
+guide](where-to-put-your-data.md) for details on how to do this). As shown
+previously, if your notebook needs ancillary files, you should include them at
+the same level as your notebook.
 
-Similarly, if your notebook involves *writing* files, you should write the notebook so that they are written in the same location.  E.g. if you are making a scatter plot using matplotlib and want to demonstrate to the user how to save it, you can do this in the notebook:
+Similarly, if your notebook involves *writing* files, you should write the
+notebook so that they are written in the same location. As an example, if you
+are making a scatter plot using matplotlib and want to demonstrate to the user
+how to save it, you can do this in the notebook:
+
 ```
 plt.scatter(...)
 plt.savefig('result-plot.png')
+
 ```
-and the image will end up in the same place as any ancillary files.
 
-## Recommended notebook structure
+And the image will end up in the same place as any ancillary files.
 
-It's recommended that Jupyter notebooks use the following suggested structure:
+## Recommended notebook and tutorial structure
+
+It's recommended that Jupyter notebooks and STScI tutorials use the following
+suggested structure:
 
 - [Title](#title)
+- [Table of Contents](#table-of-contents)
+- [Learning Goals](#learning-goals)
 - [Imports](#imports)
 - [Introduction](#introduction)
-- [Loading data](#loading-data)
-- [File information](#file-information)
+- [Loading Data](#loading-data)
+- [File Information](#file-information)
 - [Sections](#sections) (xN)
-- [Exercises](#exercises) (optional)
-- [Additional resources](#additional-resources) (optional)
-- [About this notebook](#about-this-notebook)
+- [Exercises](#exercises) (encouraged)
+- [Additional Resources](#additional-resources) (optional)
+- [About this Notebook](#about-this-notebook)
+- [Citations](#citations)
 - [Footer](#footer)
 
 ### Title
 
-Pick a clear, descriptive title. For titles, use the [following Markdown syntax](https://www.markdownguide.org/basic-syntax/#headings):
+Pick a clear, descriptive title. For titles, use [title case
+capitalization](https://docs.astropy.org/en/latest/development/style-guide.html#capitalization)
+and the following [Markdown
+syntax](https://www.markdownguide.org/basic-syntax/#headings):
 
 ```
-# My clear, descriptive title
+# My Clear, Descriptive Title
+
 ```
+
+### Table of Contents
+
+Provide a table of contents to help readers quickly navigate the sections of
+your notebook. Use the following [Markdown
+syntax](https://www.markdownguide.org/basic-syntax/):
+
+```
+## Table of Contents
+- [My First Section](#my-first-section)
+- [My Second Section](#my-second-section)
+- [My Third Section](#my-third-section)
+
+```
+
+### Learning Goals
+
+Every notebook should contain three to five explicit learning goals. A learning
+goal should describe what a reader should know or be able to do by the end of
+the notebook that they didn't know or couldn't do before.
+
+Learning goals can be broken down into:
+
+- Skills: what the reader should be able to do by the end of the notebook.
+- Knowledge: what the reader should understand by the end of the notebook.
+- Attitudes: what the reader's opinions about the subject matter will be by the
+  end of the notebook.
+
+To create your notebook learning goals, write sentences that identify what
+skill, knowledge, or attitude the reader will gain from your notebook, and use
+strong action verbs (understand, explain, demonstrate, determine, create,
+access, calculate, analyze).
+
+Template learning goal sentence:
+
+By the end of this notebook, you will be able to (skill) in order to
+(knowledge).
+
+#### Examples
+
+```
+By the end of this tutorial, you will:
+
+- Understand how to use aperture photometry to turn a series of two-dimensional
+  images into a one-dimensional time series.
+- Be able to determine the most useful aperture for photometry on a *Kepler/K2*
+  target.
+- Create your own light curve for a single quarter/campaign of *Kepler/K2* data.
+
+```
+
+```
+By the end of this tutorial, you will be able to:
+
+- Understand how NASA's Kepler Mission collected and released light curve data
+  products.
+- Download and plot light curve files from the data archive using `Lightkurve`.
+- Access light curve metadata.
+- Understand the time and brightness units.
+
+```
+
 ### Imports
 
-Import your dependencies near the top of the notebook, explaining why you're including each one. For example:
+Import your dependencies near the top of the notebook and explain why you're
+including each one. For example:
 
 ![Imports](images/imports.png)
 
 ### Introduction
 
-Write a short introduction explaining the purpose of the notebook. Link to any background materials/resources that may be useful to the reader to provide additional context.
+Write a short introduction explaining the purpose of the notebook. If there are
+background materials or resources that may be useful to the reader to provide
+additional context, you may link to it here.
 
-#### Defining terms
+#### Defining Terms
 
-Be sure to define any terms/common acronyms at the end of your introduction that your audience may not know. If you're using some kind of domain-specific astronomical symbol or unusual mathematical concept, make sure you define it (e.g. in its mathematical form) and link to any definitions (literature/Wikipedia etc.).
+As a subsection of your introduction section, define any terms or common
+acronyms that your audience may not know. If you're using some kind of
+domain-specific astronomical symbol or unusual mathematical concept, make sure
+you define it (for example, in its mathematical form) and link to any
+definitions (from literature, Wikipedia, etc.).
 
-### Loading data
+#### Companion Content
 
-If the user needs to download data to run the tutorial properly, where possible, use [Astroquery]((https://astroquery.readthedocs.io/en/latest/)) (or similar) to retrieve files. If this is not
-possible, see the [data guide](where-to-put-your-data.md) for other options.
+As a subsection of your introduction section, link to any helpful companion
+content. For example, if your notebook is a continuation from another notebook,
+or there are other notebooks that would be useful for the reader to read before
+or after your notebook, mention that here.
 
-### File information
+### Loading Data
 
-Explain pertinent details about the file you've just downloaded. For example, if working with Kepler lightcurves, explain what's in the different file extensions:
+.. should Loading Data and File Information go right after Imports? It seems
+   funny to have the Introduction separated from the main content by these two
+   sections, and might look cleaner to have all of the importing/downloading
+   info together before the learning material starts, but is there a specific
+   reason for this order?
+
+If the user needs to download data to run the tutorial properly, where possible,
+use [Astroquery](https://astroquery.readthedocs.io/en/latest/) (or similar) to
+retrieve files. If this is not possible, see the [data
+guide](where-to-put-your-data.md) for other options.
+
+### File Information
+
+Explain pertinent details about the file you've just downloaded. For example, if
+working with Kepler light curves, explain what's in the different file
+extensions:
 
 ```
-- No. 0 (Primary): This HDU contains meta-data related to the entire file.
-- No. 1 (Light curve): This HDU contains a binary table that holds data like flux measurements and times. We will extract information from here when we define the parameters for the light curve plot.
-- No. 2 (Aperture): This HDU contains the image extension with data collected from the aperture. We will also use this to display a bitmask plot that visually represents the optimal aperture used to create the SAP_FLUX column in HDU1.
+- No. 0 (Primary): This HDU contains metadata related to the entire file.
+- No. 1 (Light curve): This HDU contains a binary table that holds data like
+  flux measurements and times. We will extract information from here when we
+  define the parameters for the light curve plot.
+- No. 2 (Aperture): This HDU contains the image extension with data collected
+  from the aperture. We will also use this to display a bitmask plot that
+  visually represents the optimal aperture used to create the SAP_FLUX column in
+  HDU1.
 
 ```
 
-Where possible (if the code supports it): use code examples that use Jupyter to *show* what's in the data.  For example, if you are showing an object that can be read as an Astropy table, display the table:
+Where possible (if the code supports it): use code examples that use Jupyter to
+*show* what's in the data. For example, if you are showing an object that can be
+read as an Astropy table, display the table:
 
 ![show-data-example](images/notebook_table_data_example.png)
 
 ### Sections
 
-The meat of your notebook should be sub-divided into sections with useful names to whatever extent makes sense base on the content. Break sections up with standard [Markdown syntax headings]((https://www.markdownguide.org/basic-syntax/#headings)):
+The main content of your notebook should be subdivided into numbered sections
+with useful names that make sense based on the content. Break sections up with
+standard [Markdown syntax
+headings](https://www.markdownguide.org/basic-syntax/#headings):
 
 ```
 ## Section 1
 
-Intro to section 1
+Intro to Section 1
 
-### Sub-section 1a
+### Subsection 1a
 
 More detailed info about Section 1
 
 ## Section 2
 
-A complete thought that's as important as section 1 but doesn't need sub-sections.
+A complete thought that's as important as Section 1 but doesn't need
+subsections.
+
 ```
 
-Be sure to use section headings (i.e., the number of `#`'s) in a way that gives hierarchical meaning to your document.  The header levels are used to do things like intelligently make links, so you don't want to confuse them by using heder levels that don't match the logical flow of the document.
+Be sure to use the Markdown headings (that is, the number of `#`'s) in a way
+that gives hierarchical meaning to your document. The header levels are used to
+do things like intelligently make links, so you don't want to confuse things by
+using header levels that don't match the logical flow of the document.
 
 ### Exercises
 
-Most notebooks are trying to convey *some* information to their reader.  It's often a good idea, if possible, to include in the notebook something where there is *not* an included answer so that the reader can cement in their mind how whatever it is they were supposed to learn from that notebook. If you do have exercise(s), be sure to leave a blank code cell underneath to show the user that it's meant for them to try it out right there.  You may also want to include a "solutions" notebook next to your main notebook for the user to look at after they have finished their attempt.
+Most notebooks convey information to their reader by posing questions and then
+providing answers. But as so many of us learn by doing, it's encouraged for you
+to provide exercises in your notebook that pose questions but do not include
+immediate answers so that your reader can practice their new skills to cement
+the knowledge in their minds.
 
-### Additional resources
+If you do have one or more exercises, be sure to leave a blank code cell
+underneath to show the reader that they're meant to try out their new skill
+right there. You may also want to include a "solutions" notebook next to your
+main notebook for the reader to check their work after they have finished their
+attempt.
 
-While this isn't always necessary, sometimes you want to Provide some more resources for the reader who wants to learn something beyond what's in the notebook.  Sometimes these don't exist, but if they do, it's good to put them at the end to give the reader somewhere else to go. Usually a list of links using markdown bullet-plus-link format is appropriate:
+### Additional Resources
+
+While this section isn't always necessary, sometimes you want to provide more
+resources for the reader who wants to learn something beyond what's in the
+notebook. Sometimes these resources don't exist, but if they do, it's good to
+put them at the end to give the reader somewhere else to go. Usually a list of
+links using Markdown bulleted list plus link format is appropriate:
+
 ```
-* [A neat resource to learn more](http://learning.org/how-i-learned-science-is-cool.html)
+* [A neat resource to learn
+  more](http://learning.org/how-i-learned-science-is-cool.html)
 * [A place to find more relevant code](https://github.com/spacetelescope/jwst)
+
 ```
 
-### About this notebook
+### About this Notebook
 
-Let the world know who the author of this great notebook is! If possible/appropriate, include a contact email address for users who might need support (e.g. `archive@stsci.edu`)
+Let the world know who the author of this great notebook is! If possible and
+appropriate, include a contact email address for users who might need support
+(for example `archive@stsci.edu`). You can also optionally include keywords or
+your funding source in this section.
+
+### Citations
+
+.. what else needs to go in this section?
+
+Provide your reader with guidelines on how to cite open source software and
+other resources in their own published work.
+
+#### Example
+
+```
+If you use `astropy` or `lightkurve` for published research, please cite the
+authors. Follow these links for more information about citing `astropy` and
+`lightkurve`:
+
+* [Citing `astropy`](https://www.astropy.org/acknowledging.html)
+* [Citing `lightkurve`](http://docs.lightkurve.org/about/citing.html)
+
+```
 
 ### Footer
 
@@ -159,28 +391,38 @@ Notebooks should use the standard STScI footer:
 
 ![Footer](images/footer.png)
 
-This can be implemented with the following code snippet placed in a cell at the bottom of the notebook.
+This can be implemented with the following code snippet placed in a cell at the
+bottom of the notebook.
 
 ```
 <img style="float: right;" src="https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png" alt="Space Telescope Logo" width="200px"/>
+
 ```
 
-The [example notebook](templates/example_notebook.ipynb) implements the footer in this way.
+The [example notebook](../templates/example_notebook.ipynb) implements the
+footer in this way.
 
 ## Further reading
+
+STScI follows [The Chicago Manual of
+Style](https://www.chicagomanualofstyle.org/home.html) and the [Merriam-Webster
+Dictionary](https://www.merriam-webster.com/). STScI writing guidelines are in
+agreement with the [Astropy Narrative Style
+Guide](https://docs.astropy.org/en/stable/development/style-guide.html).
 
 ### Example notebooks following this style guide
 
 Here are some example notebooks that follow this style guide:
 
-- [An example notebook with placeholder content](templates/example_notebook.ipynb)
+- [An example notebook with placeholder content](../templates/example_notebook.ipynb)
 - [Kepler Full Frame Images (FFI)](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/Kepler_FFI/kepler_ffi.ipynb)
-- [Kepler Lightcurves](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/Kepler_Lightcurve/kepler_lightcurve.ipynb)
+- [Kepler Light Curves](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/Kepler_Lightcurve/kepler_lightcurve.ipynb)
 - [Kepler Target Pixel Files (TPF)](https://github.com/spacetelescope/notebooks/blob/master/notebooks/MAST/Kepler/Kepler_FFI/kepler_ffi.ipynb)
 
 ### Other Resources
 
-For a related view of notebook styles in the astronomy context, see the [Astropy tutorials notebook contributing guide](https://astropy-tutorials.readthedocs.io/en/latest/contributing.html#contributing-page)
+For a related view of notebook styles in the astronomy context, see the [Astropy
+Contributing Guide](http://learn.astropy.org/contributing.html)
 
 ### Contributing to the STScI notebooks repository
 

--- a/guides/jupyter-notebooks.md
+++ b/guides/jupyter-notebooks.md
@@ -296,7 +296,7 @@ extensions:
 
 ```
 
-Where possible (if the code supports it): use code examples that use Jupyter to
+Where possible (if the code supports it), use code examples that use Jupyter to
 *show* what's in the data. For example, if you are showing an object that can be
 read as an Astropy table, display the table:
 
@@ -349,8 +349,9 @@ attempt.
 While this section isn't always necessary, sometimes you want to provide more
 resources for the reader who wants to learn something beyond what's in the
 notebook. Sometimes these resources don't exist, but if they do, it's good to
-put them at the end to give the reader somewhere else to go. Usually a list of
-links using Markdown bulleted list plus link format is appropriate:
+put them at the end of your notebook to give the reader somewhere else to go.
+Usually a list of links using Markdown bullet list plus link format is
+appropriate:
 
 ```
 * [A neat resource to learn
@@ -363,7 +364,7 @@ links using Markdown bulleted list plus link format is appropriate:
 
 Let the world know who the author of this great notebook is! If possible and
 appropriate, include a contact email address for users who might need support
-(for example `archive@stsci.edu`). You can also optionally include keywords or
+(for example, `archive@stsci.edu`). You can also optionally include keywords or
 your funding source in this section.
 
 ### Citations
@@ -422,7 +423,7 @@ Here are some example notebooks that follow this style guide:
 ### Other Resources
 
 For a related view of notebook styles in the astronomy context, see the [Astropy
-Contributing Guide](http://learn.astropy.org/contributing.html)
+Contributing Guide](http://learn.astropy.org/contributing.html).
 
 ### Contributing to the STScI notebooks repository
 

--- a/templates/example_notebook.ipynb
+++ b/templates/example_notebook.ipynb
@@ -9,7 +9,7 @@
    },
    "source": [
     "<a id=\"top\"></a>\n",
-    "# Notebook Title"
+    "# Tutorial Title"
    ]
   },
   {
@@ -27,25 +27,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Table of Contents\n",
-    "Provide a table of contents to help readers quickly navigate the sections of\n",
-    "your notebook.\n",
-    "\n",
-    "```\n",
-    "## Table of Contents\n",
-    "- [My First Section](#my-first-section)\n",
-    "- [My Second Section](#my-second-section)\n",
-    "- [My Third Section](#my-third-section)\n",
-    "\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Learning Goals\n",
-    "Write three to five learning goals. A learning goal should describe what a reader should know or be able to do by the end of the notebook that they didn't know or couldn't do before.\n",
+    "Write three to five learning goals. A learning goal should describe what a reader should know or be able to do by the end of the tutorial that they didn't know or couldn't do before.\n",
     "\n",
     "```\n",
     "By the end of this tutorial, you will:\n",
@@ -98,13 +81,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Move Loading Data and File Information here??"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "***"
    ]
   },
@@ -117,14 +93,9 @@
    },
    "source": [
     "## Introduction\n",
-    "Write a short introduction explaining the purpose of the notebook. If there are background materials or resources that may be useful to the reader to provide additional context, you may link to it here.\n",
+    "Write a short introduction explaining the purpose of the tutorial. Define any terms or common acronyms that your audience may not know. If you're using some kind of domain-specific astronomical symbol or unusual mathematical concept, make sure you define it (for example, in its mathematical form) and link to any definitions (from literature, Wikipedia, etc.).\n",
     "\n",
-    "### Defining Terms\n",
-    "As a subsection of your introduction section, define any terms or common acronyms that your audience may not know. If you're using some kind of domain-specific astronomical symbol or unusual mathematical concept, make sure you define it (for example, in its mathematical form) and link to any definitions (from literature, Wikipedia, etc.).\n",
-    "\n",
-    "### Companion Content\n",
-    "As a subsection of your introduction section, link to any helpful companion content. For example, if your notebook is a continuation from another notebook, or there are other notebooks that would be useful for the reader to read before\n",
-    "or after your notebook, mention that here."
+    "If there are background materials or resources that may be useful to the reader to provide additional context, you may link to it here. If your tutorial is a continuation from another tutorial, or there are other tutorials that would be useful for the reader to read before or after your tutorial, mention that here as well."
    ]
   },
   {
@@ -191,7 +162,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Where possible (if the code supports it), use code examples that use Jupyter to show what's in the data. For example, if you are showing an object such as a Table, display a preview of the table:"
+    "Where possible (if the code supports it), use code examples that visually display the data in the tutorial. For example, if you are showing an object such as a Table, display a preview of the table:"
    ]
   },
   {
@@ -248,12 +219,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Sections (xN)\n",
+    "## Main Content\n",
     "\n",
-    "The main content of your notebook should be subdivided into numbered sections with useful names that make sense based on the content. Break sections up with standard Markdown syntax headings:\n",
+    "The main content of your tutorial should be subdivided into numbered sections with useful, descriptive headings that make sense based on the content. Break sections up with standard Markdown syntax headings:\n",
     "\n",
     "```\n",
-    "# Section 1\n",
+    "## Section 1\n",
     "\n",
     "Intro to Section 1\n",
     "\n",
@@ -273,9 +244,7 @@
    "metadata": {},
    "source": [
     "## Exercises\n",
-    "Most notebooks convey information to their reader by posing questions and then providing answers. But as so many of us learn by doing, it's encouraged for you to provide exercises in your notebook that pose questions but do not include immediate answers so that your reader can practice their new skills to cement the knowledge in their minds.\n",
-    "\n",
-    "If you do have one or more exercises, be sure to leave a blank code cell underneath to show the reader that they're meant to try out their new skill right there. You may also want to include a \"solutions\" notebook next to your main notebook for the reader to check their work after they have finished their attempt."
+    "Exercises are optional, but encouraged. Exercises can be woven into the Main Content of your tutorial, or appear in their own section toward the end of the tutorial. Final exercises can be more challenging, similar to homework problems. They can be minimal or take as long as 30 minutes to an hour to complete. If you do have one or more exercises in your tutorial, be sure to leave a blank code cell underneath each to show the reader that they're meant to try out their new skill right there. You may also want to include a \"solutions\" notebook next to your main notebook for the reader to check their work after they have finished their attempt."
    ]
   },
   {
@@ -283,7 +252,7 @@
    "metadata": {},
    "source": [
     "## Additional Resources\n",
-    "While this section isn't always necessary, sometimes you want to provide more resources for the reader who wants to learn something beyond what's in the notebook. Sometimes these resources don't exist, but if they do, it's good to put them at the end of your notebook to give the reader somewhere else to go. Usually a list of links using Markdown bullet list plus link format is appropriate:\n",
+    "While this section isn't always necessary, sometimes you want to provide more resources for the reader who wants to learn something beyond what's in your tutorial. Sometimes these resources don't exist, but if they do, it's good to put them at the end of your tutorial to give the reader somewhere else to go. Usually a list of links using Markdown bullet list plus link format is appropriate:\n",
     "\n",
     "- [MAST API](https://mast.stsci.edu/api/v0/index.html)\n",
     "- [Kepler Archive Page (MAST)](https://archive.stsci.edu/kepler/)\n",
@@ -300,7 +269,7 @@
    },
    "source": [
     "## About this Notebook\n",
-    "Let the world know who the author of this great notebook is! If possible and appropriate, include a contact email address for users who might need support (for example, `archive@stsci.edu`). You can also optionally include keywords or your funding source in this section.\n",
+    "Let the world know who the author of this great tutorial is! If possible and appropriate, include a contact email address for users who might need support (for example, `archive@stsci.edu`). You can also optionally include keywords, your funding source, or a last update date in this section.\n",
     "\n",
     "**Author:** Jessie Blogs, Archive Scientist.  \n",
     "**Updated On:** YYYY-MM-DD"

--- a/templates/example_notebook.ipynb
+++ b/templates/example_notebook.ipynb
@@ -9,7 +9,7 @@
    },
    "source": [
     "<a id=\"top\"></a>\n",
-    "# Notebook title"
+    "# Notebook Title"
    ]
   },
   {
@@ -21,6 +21,42 @@
    },
    "source": [
     "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Table of Contents\n",
+    "Provide a table of contents to help readers quickly navigate the sections of\n",
+    "your notebook.\n",
+    "\n",
+    "```\n",
+    "## Table of Contents\n",
+    "- [My First Section](#my-first-section)\n",
+    "- [My Second Section](#my-second-section)\n",
+    "- [My Third Section](#my-third-section)\n",
+    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Learning Goals\n",
+    "Write three to five learning goals. A learning goal should describe what a reader should know or be able to do by the end of the notebook that they didn't know or couldn't do before.\n",
+    "\n",
+    "```\n",
+    "By the end of this tutorial, you will:\n",
+    "\n",
+    "- Understand how to use aperture photometry to turn a series of two-dimensional\n",
+    "  images into a one-dimensional time series.\n",
+    "- Be able to determine the most useful aperture for photometry on a *Kepler/K2*\n",
+    "  target.\n",
+    "- Create your own light curve for a single quarter/campaign of *Kepler/K2* data.\n",
+    "\n",
+    "```"
    ]
   },
   {
@@ -60,17 +96,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
+   "metadata": {},
    "source": [
-    "## Introduction\n",
-    "Write a short introduction explaining the purpose of the notebook. Link to any background materials/resources that may be useful to the reader to provide additional context.\n",
-    "\n",
-    "### Defining terms\n",
-    "Be sure to define any terms/common acronyms at the end of your introduction that your audience may not know. If you're using some kind of domain-specific astronomical symbol or unusual mathematical concept, make sure you define it (e.g. in its mathematical form) and link to any definitions (literature/Wikipedia etc.)."
+    "## Move Loading Data and File Information here??"
    ]
   },
   {
@@ -88,8 +116,27 @@
     }
    },
    "source": [
-    "## Loading data\n",
-    "If the user needs to download data to run the tutorial properly, where possible, use Astroquery (or similar) to retrieve files. If this is not possible, see the [data guide](https://github.com/spacetelescope/style-guides/blob/master/guides/where-to-put-your-data.md) for other options."
+    "## Introduction\n",
+    "Write a short introduction explaining the purpose of the notebook. If there are background materials or resources that may be useful to the reader to provide additional context, you may link to it here.\n",
+    "\n",
+    "### Defining Terms\n",
+    "As a subsection of your introduction section, define any terms or common acronyms that your audience may not know. If you're using some kind of domain-specific astronomical symbol or unusual mathematical concept, make sure you define it (for example, in its mathematical form) and link to any definitions (from literature, Wikipedia, etc.).\n",
+    "\n",
+    "### Companion Content\n",
+    "As a subsection of your introduction section, link to any helpful companion content. For example, if your notebook is a continuation from another notebook, or there are other notebooks that would be useful for the reader to read before\n",
+    "or after your notebook, mention that here."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Loading Data\n",
+    "If the user needs to download data to run the tutorial properly, where possible, use [Astroquery](https://astroquery.readthedocs.io/en/latest/) (or similar) to retrieve files. If this is not possible, see the [data guide](https://github.com/spacetelescope/style-guides/blob/master/guides/where-to-put-your-data.md) for other options."
    ]
   },
   {
@@ -123,7 +170,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Where possible (if the code supports it): use code examples that use Jupyter to show what's in the data. For example, if you are showing an object such as a Table, display a preview of the table:"
+    "## File Information\n",
+    "\n",
+    "Explain pertinent details about the file you've just downloaded. For example, if working with Kepler light curves, explain what's in the different file extensions:\n",
+    "\n",
+    "```\n",
+    "- No. 0 (Primary): This HDU contains metadata related to the entire file.\n",
+    "- No. 1 (Light curve): This HDU contains a binary table that holds data like\n",
+    "  flux measurements and times. We will extract information from here when we\n",
+    "  define the parameters for the light curve plot.\n",
+    "- No. 2 (Aperture): This HDU contains the image extension with data collected\n",
+    "  from the aperture. We will also use this to display a bitmask plot that\n",
+    "  visually represents the optimal aperture used to create the SAP_FLUX column in\n",
+    "  HDU1.\n",
+    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Where possible (if the code supports it), use code examples that use Jupyter to show what's in the data. For example, if you are showing an object such as a Table, display a preview of the table:"
    ]
   },
   {
@@ -180,37 +248,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## File information\n",
-    "\n",
-    "Explain pertinent details about the file you've just downloaded. For example, if working with Kepler lightcurves, explain what's in the different file extensions:\n",
-    "\n",
-    "```\n",
-    "- No. 0 (Primary): This HDU contains meta-data related to the entire file.\n",
-    "- No. 1 (Light curve): This HDU contains a binary table that holds data like flux measurements and times. We will extract information from here when we define the parameters for the light curve plot.\n",
-    "- No. 2 (Aperture): This HDU contains the image extension with data collected from the aperture. We will also use this to display a bitmask plot that visually represents the optimal aperture used to create the SAP_FLUX column in HDU1.\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Sections (xN)\n",
     "\n",
-    "The meat of your notebook should be sub-divided into sections with useful names to whatever extent makes sense base on the content. Break sections up with standard Markdown syntax headings:\n",
+    "The main content of your notebook should be subdivided into numbered sections with useful names that make sense based on the content. Break sections up with standard Markdown syntax headings:\n",
     "\n",
     "```\n",
     "# Section 1\n",
     "\n",
-    "Intro to section 1\n",
+    "Intro to Section 1\n",
     "\n",
-    "### Sub-section 1a\n",
+    "### Subsection 1a\n",
     "\n",
     "More detailed info about Section 1\n",
     "\n",
     "## Section 2\n",
     "\n",
-    "A complete thought that's as important as section 1 but doesn't need sub-sections.\n",
+    "A complete thought that's as important as Section 1 but doesn't need subsections.\n",
+    "\n",
     "```"
    ]
   },
@@ -219,20 +273,22 @@
    "metadata": {},
    "source": [
     "## Exercises\n",
-    "Most notebooks are trying to convey _some_ information to their reader. It's often a good idea, if possible, to include in the notebook something where there is not an included answer so that the reader can cement in their mind how whatever it is they were supposed to learn from that notebook. If you do have exercise(s), be sure to leave a blank code cell underneath to show the user that it's meant for them to try it out right there. You may also want to include a \"solutions\" notebook next to your main notebook for the user to look at after they have finished their attempt."
+    "Most notebooks convey information to their reader by posing questions and then providing answers. But as so many of us learn by doing, it's encouraged for you to provide exercises in your notebook that pose questions but do not include immediate answers so that your reader can practice their new skills to cement the knowledge in their minds.\n",
+    "\n",
+    "If you do have one or more exercises, be sure to leave a blank code cell underneath to show the reader that they're meant to try out their new skill right there. You may also want to include a \"solutions\" notebook next to your main notebook for the reader to check their work after they have finished their attempt."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Aditional Resources\n",
-    "While this isn't always necessary, sometimes you want to provide some more resources for the reader who wants to learn something beyond what's in the notebook. Sometimes these don't exist, but if they do, it's good to put them at the end to give the reader somewhere else to go. Usually a list of links using markdown bullet-plus-link format is appropriate:\n",
+    "## Additional Resources\n",
+    "While this section isn't always necessary, sometimes you want to provide more resources for the reader who wants to learn something beyond what's in the notebook. Sometimes these resources don't exist, but if they do, it's good to put them at the end of your notebook to give the reader somewhere else to go. Usually a list of links using Markdown bullet list plus link format is appropriate:\n",
     "\n",
     "- [MAST API](https://mast.stsci.edu/api/v0/index.html)\n",
     "- [Kepler Archive Page (MAST)](https://archive.stsci.edu/kepler/)\n",
     "- [Kepler Archive Manual](https://archive.stsci.edu/kepler/manuals/archive_manual.pdf)\n",
-    "- [Exo.MAST website](https://exo.mast.stsci.edu/exo/ExoMast/html/exomast.html)"
+    "- [Exo.MAST website](https://exo.mast.stsci.edu/)"
    ]
   },
   {
@@ -243,11 +299,29 @@
     }
    },
    "source": [
-    "## About this notebook\n",
-    "Let the world know who the author of this great notebook is! If possible/appropriate, include a contact email address for users who might need support (e.g. archive@stsci.edu)\n",
+    "## About this Notebook\n",
+    "Let the world know who the author of this great notebook is! If possible and appropriate, include a contact email address for users who might need support (for example, `archive@stsci.edu`). You can also optionally include keywords or your funding source in this section.\n",
     "\n",
     "**Author:** Jessie Blogs, Archive Scientist.  \n",
     "**Updated On:** YYYY-MM-DD"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Citations\n",
+    "Provide your reader with guidelines on how to cite open source software and other resources in their own published work.\n",
+    "\n",
+    "```\n",
+    "If you use `astropy` or `lightkurve` for published research, please cite the\n",
+    "authors. Follow these links for more information about citing `astropy` and\n",
+    "`lightkurve`:\n",
+    "\n",
+    "* [Citing `astropy`](https://www.astropy.org/acknowledging.html)\n",
+    "* [Citing `lightkurve`](http://docs.lightkurve.org/about/citing.html)\n",
+    "\n",
+    "```"
    ]
   },
   {
@@ -282,7 +356,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/templates/example_notebook.ipynb
+++ b/templates/example_notebook.ipynb
@@ -50,6 +50,20 @@
     }
    },
    "source": [
+    "## Introduction\n",
+    "Write a short introduction explaining the purpose of the tutorial. Define any terms or common acronyms that your audience may not know. If you're using some kind of domain-specific astronomical symbol or unusual mathematical concept, make sure you define it (for example, in its mathematical form) and link to any definitions (from literature, Wikipedia, etc.).\n",
+    "\n",
+    "If there are background materials or resources that may be useful to the reader to provide additional context, you may link to it here. If your tutorial is a continuation from another tutorial, or there are other tutorials that would be useful for the reader to read before or after your tutorial, mention that here as well."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
     "## Imports\n",
     "Describe the libraries we're using here. If there's something unusual, explain what the library is, and why we need it.\n",
     "- *numpy* to handle array functions\n",
@@ -86,16 +100,26 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
+   "metadata": {},
    "source": [
-    "## Introduction\n",
-    "Write a short introduction explaining the purpose of the tutorial. Define any terms or common acronyms that your audience may not know. If you're using some kind of domain-specific astronomical symbol or unusual mathematical concept, make sure you define it (for example, in its mathematical form) and link to any definitions (from literature, Wikipedia, etc.).\n",
+    "## Main Content\n",
     "\n",
-    "If there are background materials or resources that may be useful to the reader to provide additional context, you may link to it here. If your tutorial is a continuation from another tutorial, or there are other tutorials that would be useful for the reader to read before or after your tutorial, mention that here as well."
+    "The main content of your tutorial should be subdivided into numbered sections with useful, descriptive headings that make sense based on the content. Break sections up with standard Markdown syntax headings:\n",
+    "\n",
+    "```\n",
+    "## Section 1\n",
+    "\n",
+    "Intro to Section 1\n",
+    "\n",
+    "### Subsection 1a\n",
+    "\n",
+    "More detailed info about Section 1\n",
+    "\n",
+    "## Section 2\n",
+    "\n",
+    "A complete thought that's as important as Section 1 but doesn't need subsections.\n",
+    "\n",
+    "```"
    ]
   },
   {
@@ -106,7 +130,10 @@
     }
    },
    "source": [
-    "## Loading Data\n",
+    "### Loading Data\n",
+    "\n",
+    "Loading data and file information should appear within your main content, at the same time the data is going to be used, if possible. These elements of your tutorial can be their own sections within the main content, but avoid generic or vague headings like “Loading Data” and instead use descriptive headings pertinent to the content of the tutorial and the actual data being downloaded or files being used.\n",
+    "\n",
     "If the user needs to download data to run the tutorial properly, where possible, use [Astroquery](https://astroquery.readthedocs.io/en/latest/) (or similar) to retrieve files. If this is not possible, see the [data guide](https://github.com/spacetelescope/style-guides/blob/master/guides/where-to-put-your-data.md) for other options."
    ]
   },
@@ -141,7 +168,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## File Information\n",
+    "### File Information\n",
     "\n",
     "Explain pertinent details about the file you've just downloaded. For example, if working with Kepler light curves, explain what's in the different file extensions:\n",
     "\n",
@@ -219,32 +246,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Main Content\n",
-    "\n",
-    "The main content of your tutorial should be subdivided into numbered sections with useful, descriptive headings that make sense based on the content. Break sections up with standard Markdown syntax headings:\n",
-    "\n",
-    "```\n",
-    "## Section 1\n",
-    "\n",
-    "Intro to Section 1\n",
-    "\n",
-    "### Subsection 1a\n",
-    "\n",
-    "More detailed info about Section 1\n",
-    "\n",
-    "## Section 2\n",
-    "\n",
-    "A complete thought that's as important as Section 1 but doesn't need subsections.\n",
-    "\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Exercises\n",
-    "Exercises are optional, but encouraged. Exercises can be woven into the Main Content of your tutorial, or appear in their own section toward the end of the tutorial. Final exercises can be more challenging, similar to homework problems. They can be minimal or take as long as 30 minutes to an hour to complete. If you do have one or more exercises in your tutorial, be sure to leave a blank code cell underneath each to show the reader that they're meant to try out their new skill right there. You may also want to include a \"solutions\" notebook next to your main notebook for the reader to check their work after they have finished their attempt."
+    "Exercises are optional, but encouraged. Exercises can be woven into the main content of your tutorial, or appear in their own section toward the end of the tutorial. Final exercises can be more challenging, similar to homework problems. They can be minimal or take as long as 30 minutes to an hour to complete. If you do have one or more exercises in your tutorial, be sure to leave a blank code cell underneath each to show the reader that they're meant to try out their new skill right there. You may also want to include a \"solutions\" notebook next to your main notebook for the reader to check their work after they have finished their attempt."
    ]
   },
   {
@@ -252,7 +255,8 @@
    "metadata": {},
    "source": [
     "## Additional Resources\n",
-    "While this section isn't always necessary, sometimes you want to provide more resources for the reader who wants to learn something beyond what's in your tutorial. Sometimes these resources don't exist, but if they do, it's good to put them at the end of your tutorial to give the reader somewhere else to go. Usually a list of links using Markdown bullet list plus link format is appropriate:\n",
+    "\n",
+    "This section is optional. Try to weave resource links into the main content of your tutorial so that they are falling in line with the context of your writing. For resources that do not fit cleanly into your narrative, you may include an additional resources section at the end of your tutorial. Usually a list of links using Markdown bullet list plus link format is appropriate:\n",
     "\n",
     "- [MAST API](https://mast.stsci.edu/api/v0/index.html)\n",
     "- [Kepler Archive Page (MAST)](https://archive.stsci.edu/kepler/)\n",


### PR DESCRIPTION
This pull request is to revise and update the STScI Jupyter Notebook style guide as part of the Kepler-Focus Lightkurve Tutorial project to create a reconciled tutorial template for the new Lightkurve tutorials as well as for Astropy and STScI tutorials moving forward. This pull request contains copy edits to the text of the Jupyter Notebook style guide as well as revisions and additions to the suggested notebook structure and the example notebook.

~~Note for @eteq, @kelle, and @barentsen, drawing attention to three questions I had marked by ... in the files:~~
- ~~Line 3: question about the terms "notebook" vs. "tutorial"~~
- ~~Line 270: can Loading Data and File Information be moved to go after Imports instead~~
- ~~Line 372: was there any other information that should go in the Citations section~~

