### PR TITLE
MNT: Update package template instructions

### DIFF
--- a/guides/python-package.md
+++ b/guides/python-package.md
@@ -1,9 +1,9 @@
 # Python Packaging
 
 The following guide is to simplify the process of creating a python
-package.  We currently recommend using the [STScI cookie cutter
-template package](https://github.com/spacetelescope/stsci-package-template/tree/stsci-cookiecutter).  
-This is a modified version of the [Astropy
+package.  We currently recommend using the [STScI package
+template](https://github.com/spacetelescope/stsci-package-template).
+This is a simplified and modified version of the [Astropy
 Template Package](https://github.com/astropy/package-template) that
 includes a number of features that make it easier to set up, install,
 and maintain your package while also having the STScI branding,
@@ -12,7 +12,7 @@ repositories](https://github.com/spacetelescope/style-guides/blob/master/guides/
 This includes the infrastructure to set up the automated testing and
 documentation.
 
-The following steps will allow the creation of astropy affiliated
+The following steps will allow the creation of Astropy affiliated
 packages compatible with the STScI requirements.  However, this might
 not always be appropriate for each package and we currently do not
 recommend existing packages update to these standards.
@@ -32,10 +32,10 @@ code:
 
 * General astronomy related functionality?  Have you consider contributing to astropy?
 * Access to a database or a catalog?   This would be a good fit for astroquery!
-* Spectral tools?   Have you considered specutils or specviz? 
+* Spectral tools?   Have you considered specutils or specviz?
 * Analysis tools for an HST instrument?  Consider contributing to one of the HST tools packages like
 * Will this be useful for JWST?  Consider contribute to the JWST library.
- 
+
 This list is hardly exhaustive, but provides an example of where to
 contribute code.  If unsure, opening an issue in a repository to ask
 is a very good way to find out if it is appropriate to contribute the
@@ -60,7 +60,7 @@ Following [STScI policy on source code
 control](https://innerspace.stsci.edu/display/isec/Source+Code+Control),
 the decision tree on where to host code is the following:
 
-* Is it ITAR protected?  Then host it on internal git ITAR server. 
+* Is it ITAR protected?  Then host it on internal git ITAR server.
 * Is it functional work?   Then it must be hosted on the STScI GitLab solution or the `spacetelescope` organization on GitHub
 * Will it have external collaborators?  Then it is recommended to host it on the `spacetelescope` organization on GitHub
 
@@ -68,7 +68,7 @@ Code hosted on GitHub should follow the [STScI GitHub
 Policy](https://innerspace.stsci.edu/display/isec/GitHub).
 
 
-### Creating an new repository  
+### Creating an new repository
 
 For GitHub:
 
@@ -89,57 +89,27 @@ their own new repository.
 
 ### Create a new package
 
-To create a new package, we recommend the following steps.  These make
-use the
-[cookiecutter](https://cookiecutter.readthedocs.io/en/latest/index.html)
-package to quickly create a basic package with the infrastructure
-needed for coding, testing, and documentation.
+To create a new package, we recommend the following steps.
 
-1.  Install the cookie cutter package
+1. Go to https://github.com/spacetelescope/stsci-package-template .
 
-The cookiecutter package can either be installed using `pip`:
-```pip install cookiecutter gitpython```
+2. Click "Use this template" button (it is big and green).
 
-or `conda`:
+See https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template
+for more info.
 
-```conda install  -c conda-forge cookiecutter gitpython```
+3. Register your package on https://codecov.io if you want test coverage.
 
-2. Run cookiecutter using the STScI package template:
-```
-cookiecutter https://github.com/spacetelescope/stsci-package-template --checkout stsci-cookiecutter
-```
+4. Set up ReadTheDocs (RTD)
 
-The code will prompt for answers to several questions.  Other than the
-repository name and github project, the default answer will be
-sufficient in most cases.
-
-3.  Set up continuous integration
-
-Register your package on https://travis-ci.org and modify the
-.travis.yml file to your needs. The default .travis.yml file contains
-a large number of builds, against various versions of Python, Astropy,
-and numpy, and you should choose the ones relevant to your
-project. Full documentation of the .travis.yml file can be found on
-the Travis CI website.
-
-
-4.  Set up read the docs
-
-If you want the documentation for your project to be hosted by Read
-the Docs, then you need to setup an account there. The following
-entries in `Advanced Settings` for your package on Read the Docs
-should work:
-
-* Select Install your project inside a virtualenv using setup.py install
-* Edit .rtd-environment.yml with your package requirements (this file is used by conda on RTD to install the requirements for your package).
-* Activate Give the virtual environment access to the global site-packages dir.
-* All other settings can stay on their default value.
-
+If you want the documentation for your project to be hosted by
+RTD, then you need to set up an account there. Your RTD
+settings are controlled by `.readthedocs.yml` in your repository.
+Optionally, you can enable "Build pull requests for this project"
+under Advanced Settings in Admin section.
 
 Once these steps have been completed, the package should be ready for
 further development with testing and documentation in place.
-
-
 
 ### Additional Reading
 

--- a/guides/python-package.md
+++ b/guides/python-package.md
@@ -98,9 +98,11 @@ To create a new package, we recommend the following steps.
 See https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template
 for more info.
 
-3. Register your package on https://codecov.io if you want test coverage.
+3. Carefully go through your new repository and customize as needed.
 
-4. Set up ReadTheDocs (RTD)
+4. Register your package on https://codecov.io if you want test coverage.
+
+5. Set up ReadTheDocs (RTD)
 
 If you want the documentation for your project to be hosted by
 RTD, then you need to set up an account there. Your RTD


### PR DESCRIPTION
https://github.com/spacetelescope/stsci-package-template was way outdated, so I updated it. These instructions should be compatible with the updated template.