### PR TITLE
Remove pytest-openfiles from recommended Python testing tools

### DIFF
--- a/guides/python-testing.md
+++ b/guides/python-testing.md
@@ -13,9 +13,6 @@ out of your tests. Example of several useful ones:
 
 * [pytest-doctestplus](https://github.com/astropy/pytest-doctestplus) for
   advanced features for testing example code in documentation.
-* [pytest-openfiles](https://github.com/astropy/pytest-openfiles) for
-  detecting file handles that were inadvertently left open at the end of
-  unit tests.
 * [pytest-arraydiff](https://github.com/astrofrog/pytest-arraydiff) for
   generation and comparison of data arrays produced during unit tests.
 * [pytest-socket](https://github.com/miketheman/pytest-socket) for handling

--- a/guides/python-testing.md
+++ b/guides/python-testing.md
@@ -11,9 +11,9 @@ as you deem necessary.
 There are many ``pytest`` plugins that you could utilize to get the most
 out of your tests. Example of several useful ones:
 
-* [pytest-doctestplus](https://github.com/astropy/pytest-doctestplus) for
+* [pytest-doctestplus](https://github.com/scientific-python/pytest-doctestplus) for
   advanced features for testing example code in documentation.
-* [pytest-arraydiff](https://github.com/astrofrog/pytest-arraydiff) for
+* [pytest-arraydiff](https://github.com/astropy/pytest-arraydiff) for
   generation and comparison of data arrays produced during unit tests.
 * [pytest-socket](https://github.com/miketheman/pytest-socket) for handling
   network calls.


### PR DESCRIPTION
`astropy` will no longer use it. There are now other ways to check for unclosed resources. See

* https://github.com/astropy/astropy/pull/14041